### PR TITLE
fixed passing default currency

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -39,6 +39,7 @@ class PurchaseRequest extends AbstractRequest
         $data['merchant_order_id'] = $this->getTransactionId();
         $data['total'] = $this->getAmount();
         $data['tco_currency'] = $this->getCurrency();
+        $data['currency_code'] = $this->getCurrency();
         $data['fixed'] = 'Y';
         $data['skip_landing'] = 1;
         $data['x_receipt_link_url'] = $this->getReturnUrl();


### PR DESCRIPTION
problem:
if we are not using USD for defualt currency, 2checkout will automatic to change currency rate, like say i pass $10 HKD, then system show $78 HKD.

if we wanna pass default currency, so that pass $10HKD, then show $10 HKD.
 
