### PR TITLE
Updated package to use Omnipay v3 library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,29 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4snapshot
 
-before_script:
-  - composer install -n --dev --prefer-source
+# This triggers builds to run on the new TravisCI infrastructure.
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
 
-script: vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text
+matrix:
+  allow_failures:
+    - php: 7.4snapshot
+
+## Cache composer
+cache:
+  directories:
+    - $HOME/.composer/cache
+    
+install:
+  - composer install --prefer-dist --no-interaction
+
+script: 
+  - vendor/bin/phpcs --standard=PSR2 src
+  - vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
-        "omnipay/tests": "^3.0"
+        "omnipay/tests": "^3.0",
+        "squizlabs/php_codesniffer": "^3"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,12 @@
         "psr-4": { "Omnipay\\TwoCheckout\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "^3.0",
+        "league/omnipay": "^3",
+        "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
+        "omnipay/tests": "^3.0"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,9 +14,6 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="Mockery\Adapter\Phpunit\TestListener" file="vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php" />
-    </listeners>
     <filter>
         <whitelist>
             <directory>./src</directory>


### PR DESCRIPTION
This is a PR to make the package compatible with V3 of the Omnipay library, which is required for Symfony 3+ and associated components.